### PR TITLE
Support double quotes for the version value on metadata.rb file

### DIFF
--- a/spife.go
+++ b/spife.go
@@ -131,6 +131,7 @@ func metadata(path, bumpLevel string) string {
 
 	for i, line := range lines {
 		if strings.Contains(line, "version") {
+			line = strings.Replace(line, "\"", "'", 2)
 			lineArray := strings.Split(line, "'")
 			fmt.Printf("Current version: %s\n", lineArray[1])
 


### PR DESCRIPTION
Fix https://github.com/palourde/spife/issues/1
