### PR TITLE
A more strict pattern matching to detect cookbook version in metadata

### DIFF
--- a/spife.go
+++ b/spife.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -130,7 +131,8 @@ func metadata(path, bumpLevel string) string {
 	newVersion := Version{}
 
 	for i, line := range lines {
-		if strings.Contains(line, "version") {
+		matchedVersionPattern, _ := regexp.MatchString("^( |\t)*version( |\t)+(\\'|\")(.+)(\\'|\")", line)
+		if matchedVersionPattern {
 			line = strings.Replace(line, "\"", "'", 2)
 			lineArray := strings.Split(line, "'")
 			fmt.Printf("Current version: %s\n", lineArray[1])
@@ -149,6 +151,7 @@ func metadata(path, bumpLevel string) string {
 			fmt.Printf("New version: %s\n", lineArray[1])
 
 			lines[i] = strings.Join(lineArray, "'")
+			break
 		}
 	}
 


### PR DESCRIPTION
This will avoid failure if the word version is used elsewhere in the metadata.rb.

Also, if we found out the «version», stop to search for it in the file.